### PR TITLE
 metworx refactor: small updates

### DIFF
--- a/R/read-results.R
+++ b/R/read-results.R
@@ -67,6 +67,6 @@ read_manual_test_results <- function(test_output_dir) {
   results %>%
     extract(.data$content, "date", "\n\\* date: +(.*)",
             remove = FALSE) %>%
-    extract(.data$content, "test_name", "\nMAN-[A-Z]+-[0-9]+: +(.*)",
+    extract(.data$content, "test_name", "## MAN-[A-Z]+-[0-9]+: +(.*)",
             remove = FALSE)
 }

--- a/R/write-validation-testing.R
+++ b/R/write-validation-testing.R
@@ -104,10 +104,9 @@ of test failures.
       failed = sum(.data$failed)
     )
 
-  cat(file = out_file,  glue("\n\n**Count of manual tests:** {sum_man}"), "\n", append = TRUE)
   cat(file = out_file,  val_summary, "\n", append = TRUE)
   cat(file = out_file, knitr::kable(sum_auto_df), sep = "\n", append = TRUE)
-
+  cat(file = out_file,  glue("\n\n**Count of manual tests:** {sum_man}"), "\n", append = TRUE)
 
   # add automated test outputs
   cat(file = out_file,  "\n# Automated Test Results\n", append = TRUE)


### PR DESCRIPTION
* fix placement of manual counts in validation testing output

* Update regexp for extracting manual test names (format changed upstream)
