### PR TITLE
update doc formats for Aing's feedback

### DIFF
--- a/R/generate-docs.R
+++ b/R/generate-docs.R
@@ -7,6 +7,8 @@
 #'   [read_spec_gsheets()].
 #' @param auto_test_dir,man_test_dir path to directories containing automatic
 #'   and manual test output files. See [input_formats].
+#' @param roles A data frame of user roles that, if specified, is inserted into
+#'   the requirements document.
 #' @param output_dir Directory to write the output documents to. Defaults to
 #'   working directory.
 #' @importFrom dplyr bind_rows full_join mutate rename
@@ -17,7 +19,7 @@
 create_validation_docs <- function
 (
   product_name, version, specs,
-  auto_test_dir = NULL, man_test_dir = NULL,
+  auto_test_dir = NULL, man_test_dir = NULL, roles = NULL,
   output_dir = getwd()
 ) {
 
@@ -69,6 +71,7 @@ create_validation_docs <- function
     dd,
     product_name,
     version,
+    roles = roles,
     out_file = REQ_FILE,
     output_dir = output_dir,
     word_document = TRUE

--- a/R/utils.R
+++ b/R/utils.R
@@ -82,8 +82,8 @@ format_spec <- function(x) {
   tst_tab <- knitr::kable(tst, format="markdown")
   c(header,
     bod, "\n\n",
-    "**Summary**\n", reqs, "\n\n",
     "**Product risk**: ", risk, "\n\n",
+    "**Summary**\n", reqs, "\n\n",
     "**Tests**\n\n", tst_tab)
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -67,7 +67,7 @@ proc_issue <- function(txt) {
 #' @importFrom stringr str_squish
 #' @param x A single row from the [process_stories()] df
 format_spec <- function(x) {
-  header <- paste0("## ", x$StoryId[[1]], " ", x$StoryName[[1]], "\n")
+  header <- paste0("## User Story: ", x$StoryId[[1]], " ", x$StoryName[[1]], "\n")
   bod <- gsub("\r", "", x$StoryDescription[[1]])
   risk <- gsub("risk: ", "", x$ProductRisk[[1]])
 
@@ -80,9 +80,10 @@ format_spec <- function(x) {
   tst <- x %>%
     select(`test ID` = .data$TestId, `test name` = .data$test_name)
   tst_tab <- knitr::kable(tst, format="markdown")
-  c(header, "**Product risk**: ", risk, "\n\n",
-    "**Story**\n", bod, "\n\n",
-    "**Requirements**\n", reqs, "\n\n",
+  c(header,
+    bod, "\n\n",
+    "**Summary**\n", reqs, "\n\n",
+    "**Product risk**: ", risk, "\n\n",
     "**Tests**\n\n", tst_tab)
 }
 

--- a/R/write-requirements.R
+++ b/R/write-requirements.R
@@ -3,12 +3,15 @@
 #' @importFrom purrr map walk
 #' @importFrom dplyr distinct filter group_rows slice
 #' @importFrom glue glue
+#' @importFrom knitr kable
 #' @importFrom rmarkdown render
 #' @importFrom fs dir_exists dir_create
 #' @importFrom rlang .data
 #' @param df Tibble output from [process_stories()].
 #' @param product_name The product you are validating, to be included in the output document.
 #' @param version The version number of the product you are validating, to be included in the output document.
+#' @param roles A data frame of user roles. If specified, this will be
+#'   inserted as a table under a "User Roles" section.
 #' @param out_file filename to write markdown file out to. Any extension will be ignored and replaced with .md
 #' @param output_dir Directory to write the output documents to. Defaults to working directory.
 #' @param word_document Logical scaler indicating whether to render a docx document
@@ -17,6 +20,7 @@ write_requirements <- function(
   df,
   product_name,
   version,
+  roles = NULL,
   out_file = REQ_FILE,
   output_dir = getwd(),
   word_document = TRUE
@@ -37,6 +41,11 @@ document. The Requirement Specifications ensure that each requirement is tested.
 ')
 
   cat(file=out_file, req_boiler, "\n")
+
+  if (!is.null(roles)) {
+    cat("## User Roles\n", kable(roles), "\n",
+        append = TRUE, file = out_file, sep = "\n")
+  }
 
   df_story <- df %>%
     filter(!is.na(.data$StoryId)) %>%

--- a/R/write-traceability-matrix.R
+++ b/R/write-traceability-matrix.R
@@ -31,10 +31,9 @@ write_traceability_matrix <- function(
 
 ## Scope
 
-This traceability matrix links product risk, test names, and test results to
+This traceability matrix links requirement specifications and test results to
 specific user stories for the proposed software release. User stories, including
-requirements and test specifications are listed in the Requirements Specification
-and Validation Plan.
+requirements and test specifications are listed in the Requirements Specification.
 
 ')
 
@@ -43,23 +42,15 @@ and Validation Plan.
     unnest(cols = c(.data$tests)) %>%
     filter(!is.na(.data$passed)) %>%
     mutate(number = .data$passed + .data$failed,
-           date = format(strptime(.data$date, format = ""), "%Y-%m-%d"),
-           story_title = paste(.data$StoryId, .data$StoryName),
            pass = paste0(.data$number - .data$failed, " of ", .data$number)) %>%
-    arrange(.data$story_title, .data$RequirementId, .data$TestId)
+    arrange(.data$StoryId, .data$RequirementId, .data$TestId)
 
-  mat$story_title[duplicated(mat$story_title)] <- ""
-  dup_story_req <- duplicated(paste0(mat$StoryId, mat$RequirementId))
-  mat$RequirementId[dup_story_req] <- ""
-
+  mat$StoryDescription[duplicated(mat$StoryDescription)] <- ""
   mat_out <- select(
     mat,
-    `story title` = .data$story_title,
-    `requirement ID` = .data$RequirementId,
-    risk = .data$ProductRisk,
+    `User Story` = .data$StoryDescription,
     `test ID` = .data$TestId,
     .data$pass,
-    `date run` = .data$date
   )
 
   cat(file = out_file,  mat_boiler,"\n")

--- a/R/write-traceability-matrix.R
+++ b/R/write-traceability-matrix.R
@@ -48,7 +48,7 @@ requirements and test specifications are listed in the Requirements Specificatio
   mat$StoryDescription[duplicated(mat$StoryDescription)] <- ""
   mat_out <- select(
     mat,
-    `User Story` = .data$StoryDescription,
+    `user story` = .data$StoryDescription,
     `test ID` = .data$TestId,
     .data$pass,
   )

--- a/R/write-traceability-matrix.R
+++ b/R/write-traceability-matrix.R
@@ -33,7 +33,7 @@ write_traceability_matrix <- function(
 
 This traceability matrix links requirement specifications and test results to
 specific user stories for the proposed software release. User stories, including
-requirements and test specifications are listed in the Requirements Specification.
+requirements and test specifications, are listed in the Requirements Specification.
 
 ')
 

--- a/R/write-validation-testing.R
+++ b/R/write-validation-testing.R
@@ -48,8 +48,6 @@ write_validation_testing <- function(
     tests <- filter(tests, !is.na(.data$TestId))
   }
 
-  test_suites <- unique(tests$result_file)
-
   # write to top section to file
   val_boiler <- glue('
 ---
@@ -68,45 +66,10 @@ number_sections: yes
 The purpose of this Validation Testing document is to define the conditions for
 test execution and present the test results. All tests are specified and linked
 to release candidate user stories as numbered issues in the Requirements
-Specification-Validation Plan document.
-
-----------------
-
-## Test locations
-
-Tests are in the following location(s):
-
-{paste0(1:length(test_suites), ".\t", test_suites, collapse = "\n")}
+Specification document.
 
 ')
   cat(file = out_file,  val_boiler,"\n")
-
-  val_summary <- '
-
-## Comprehensive summary
-
-Summarizes the number of test suites, tests, and expectations and counts number
-of test failures.
-
-**Counts of automated tests:**
-'
-
-  sum_man <- tests %>%
-    filter(.data$test_type == "manual") %>%
-    nrow()
-
-  sum_auto_df <- tests %>%
-    filter(.data$test_type == "automatic") %>%
-    summarise(
-      suites = length(unique(.data$result_file)),
-      tests = n(),
-      assertions = sum(.data$passed) + sum(.data$failed),
-      failed = sum(.data$failed)
-    )
-
-  cat(file = out_file,  val_summary, "\n", append = TRUE)
-  cat(file = out_file, knitr::kable(sum_auto_df), sep = "\n", append = TRUE)
-  cat(file = out_file,  glue("\n\n**Count of manual tests:** {sum_man}"), "\n", append = TRUE)
 
   # add automated test outputs
   cat(file = out_file,  "\n# Automated Test Results\n", append = TRUE)

--- a/man/create_validation_docs.Rd
+++ b/man/create_validation_docs.Rd
@@ -10,6 +10,7 @@ create_validation_docs(
   specs,
   auto_test_dir = NULL,
   man_test_dir = NULL,
+  roles = NULL,
   output_dir = getwd()
 )
 }
@@ -23,6 +24,9 @@ create_validation_docs(
 
 \item{auto_test_dir, man_test_dir}{path to directories containing automatic
 and manual test output files. See \link{input_formats}.}
+
+\item{roles}{A data frame of user roles that, if specified, is inserted into
+the requirements document.}
 
 \item{output_dir}{Directory to write the output documents to. Defaults to
 working directory.}

--- a/man/write_requirements.Rd
+++ b/man/write_requirements.Rd
@@ -8,6 +8,7 @@ write_requirements(
   df,
   product_name,
   version,
+  roles = NULL,
   out_file = REQ_FILE,
   output_dir = getwd(),
   word_document = TRUE
@@ -19,6 +20,9 @@ write_requirements(
 \item{product_name}{The product you are validating, to be included in the output document.}
 
 \item{version}{The version number of the product you are validating, to be included in the output document.}
+
+\item{roles}{A data frame of user roles. If specified, this will be
+inserted as a table under a "User Roles" section.}
 
 \item{out_file}{filename to write markdown file out to. Any extension will be ignored and replaced with .md}
 


### PR DESCRIPTION
The first three commits of this series directly map to suggestions made by Aing.  The next ones are just minor traceability matrix tweaks on top; I separated them out so that they're not confused with Aing's suggestions.

And the last commit adds support for the suggestion of including a "User Roles" table in the requirements doc.  (Tim's working on putting together the upstream google sheets source for this, but the details of the table don't matter from the point of view of `create_validation_docs` and`write_requirements`.)

I believe the only remaining suggestion deals with the suite-level details for the automated tests that are inserted into the validation docs (`executor`, ...).  That's ultimately up to whoever writes the input JSON file, though we probably want to adapt `get_sys_info` be closer to the recommended format (e.g., don't include `sys` fields by default and add parameters like `executor` for the caller to specify).

