### PR TITLE
fix: write_requirements: restore summary of requirements

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -31,7 +31,7 @@ format_spec <- function(x) {
   c(header,
     bod, "\n\n",
     "**Product risk**: ", risk, "\n\n",
-    ifelse(is.null(reqs), "", c("**Summary**\n", reqs, "\n\n")),
+    if(is.null(reqs)) "" else c("**Summary**\n", reqs, "\n\n"),
     "**Tests**\n\n", tst_tab)
 }
 


### PR DESCRIPTION
The requirements document is supposed to include a "Summary" header
followed by a list of requirements.  The list of requirements was lost
in 13657f2 (feat: make requirements optional for specs, 2021-08-04).
The problem is a vectorized ifelse(SCALAR, "", VECTOR) call that leads
to dropping all of VECTOR except for the first item (`"**Summary**\n"`).

Use a plain if/else instead.