### PR TITLE
fix: write_validation_testing: conditionally add auto/manual headings

### DIFF
--- a/R/write-validation-testing.R
+++ b/R/write-validation-testing.R
@@ -68,13 +68,15 @@ Specification document.
 ')
   cat(file = out_file,  val_boiler,"\n")
 
-  # add automated test outputs
-  cat(file = out_file,  "\n# Automated Test Results\n", append = TRUE)
+  auto_tests <- filter(tests, .data$test_type == "automatic")
+  if (nrow(auto_tests) != 0) {
+    # add automated test outputs
+    cat(file = out_file,  "\n# Automated Test Results\n", append = TRUE)
 
-  walk(names(auto_info), ~ {
-    .suite <- auto_info[[.x]]
+    walk(names(auto_info), ~ {
+      .suite <- auto_info[[.x]]
 
-    val_info <- glue('
+      val_info <- glue('
 
 ### {.x}
 
@@ -86,28 +88,30 @@ Specification document.
 
 ')
 
-    # filter to relevant tests
-    test_df <- tests %>%
-      filter(.data$result_file == .x) %>%
-      select(
-        `Test ID` = .data$TestId,
-        `Test name` = .data$TestName,
-        .data$passed,
-        .data$failed
-      )
+      # filter to relevant tests
+      test_df <- auto_tests %>%
+        filter(.data$result_file == .x) %>%
+        select(
+          `Test ID` = .data$TestId,
+          `Test name` = .data$TestName,
+          .data$passed,
+          .data$failed
+        )
 
-    # write to file
-    cat(file = out_file,  val_info, sep = "\n", append = TRUE)
-    cat(file = out_file, knitr::kable(test_df), sep = "\n", append = TRUE)
-  })
+      # write to file
+      cat(file = out_file,  val_info, sep = "\n", append = TRUE)
+      cat(file = out_file, knitr::kable(test_df), sep = "\n", append = TRUE)
+    })
+  }
 
   # write manual test outputs
-  cat(file = out_file,  "\n# Manual Test Results\n", append = TRUE)
 
-  tests %>%
-    filter(.data$test_type == "manual") %>%
-    pull(.data$man_test_content) %>%
-    walk(~ cat(file = out_file,  glue("\n{.x}\n\n"), append = TRUE))
+  man_tests <- filter(tests, .data$test_type == "manual")
+  if (nrow(man_tests) != 0) {
+    cat(file = out_file,  "\n# Manual Test Results\n", append = TRUE)
+    pull(man_tests, .data$man_test_content) %>%
+      walk(~ cat(file = out_file,  glue("\n{.x}\n\n"), append = TRUE))
+  }
 
   message(glue("Finished writing to {out_file}"))
 

--- a/tests/testthat/test-create-validation-docs.R
+++ b/tests/testthat/test-create-validation-docs.R
@@ -85,6 +85,43 @@ test_that("create_validation_docs() returns data df", {
 
 })
 
+test_that("create_validation_docs() drops missing test types", {
+  output_dir <- file.path(tempdir(), "mrgvalidate-create-validation-docs")
+  if (fs::dir_exists(output_dir)) fs::dir_delete(output_dir)
+  fs::dir_create(output_dir)
+  on.exit(fs::dir_delete(output_dir))
+
+  specs <- readRDS(file.path(TEST_INPUTS_DIR, "specs.RDS"))
+
+  outdir_auto <- file.path(output_dir, "auto")
+  fs::dir_create(outdir_auto)
+
+  create_validation_docs(
+    product_name = "Metworx TEST",
+    version = "vFAKE",
+    specs = specs,
+    auto_test_dir = file.path(TEST_INPUTS_DIR, "validation-results-sample"),
+    output_dir = outdir_auto)
+
+  val_text_auto <- readr::read_file(file.path(outdir_auto, VAL_FILE))
+  expect_true(str_detect(val_text_auto, "# Automated Test Results"))
+  expect_false(str_detect(val_text_auto, "# Manual Test Results"))
+
+  outdir_man <- file.path(output_dir, "man")
+  fs::dir_create(outdir_man)
+
+  create_validation_docs(
+    product_name = "Metworx TEST",
+    version = "vFAKE",
+    specs = specs,
+    man_test_dir = file.path(TEST_INPUTS_DIR, "manual-tests-sample"),
+    output_dir = outdir_man)
+
+  val_text_man <- readr::read_file(file.path(outdir_man, VAL_FILE))
+  expect_false(str_detect(val_text_man, "# Automated Test Results"))
+  expect_true(str_detect(val_text_man, "# Manual Test Results"))
+})
+
 test_that("create_validation_docs() works with no requirements", {
   # set up clean docs output dir
   output_dir <- file.path(tempdir(), "mrgvalidate-create-validation-docs")


### PR DESCRIPTION
It's valid to have only one type of tests, automatic or manual.
However, write_validation_testing() unconditionally includes the
"Automated Test Results" and "Manual Test Results" headings.

Check that tests of a given type exist before outputting a heading for
them.