### PR TITLE
read-results: more informative error messages

### DIFF
--- a/R/read-results.R
+++ b/R/read-results.R
@@ -13,6 +13,12 @@
 #' @keywords internal
 read_csv_test_results <- function(test_output_dir) {
   csv_files <- list.files(test_output_dir, pattern = "\\.csv$", full.names = TRUE)
+  if (length(csv_files) == 0) {
+    rlang::abort(
+      glue("No .csv files found in {test_output_dir}"),
+      "mrgvalidate_input_error")
+  }
+
   json_files <- str_replace(csv_files, "\\.csv$", ".json")
 
   for (.j in json_files) {

--- a/R/read-results.R
+++ b/R/read-results.R
@@ -62,6 +62,12 @@ read_manual_test_results <- function(test_output_dir) {
   test_output_dir <- str_replace(test_output_dir, "/$", "")
   testdirs <- list.files(test_output_dir, pattern = "^MAN-[A-Z]+-[0-9]+",
                          full.names = TRUE)
+  if (length(testdirs) == 0) {
+    rlang::abort(
+      glue("No 'MAN-[A-Z]+-[0-9]+' directories found in {test_output_dir}"),
+      "mrgvalidate_input_error")
+  }
+
   results <- map_dfr(testdirs, function(.dir) {
     .id <- basename(.dir)
     abs_asset_path <- file.path(.dir, paste0("assets_", .id))

--- a/tests/testthat/test-read-results.R
+++ b/tests/testthat/test-read-results.R
@@ -17,6 +17,13 @@ test_that("read_csv_test_results() can read test results", {
                                   "^[0-9]+\\-[0-9]+\\-[0-9]+"))
 })
 
+test_that("read_csv_test_results() gives helpful error if no CSVs are found", {
+  withr::with_tempdir({
+    expect_error(read_csv_test_results(getwd()),
+                 class = "mrgvalidate_input_error")
+  })
+})
+
 test_that("read_csv_test_results() errors if JSON sidecar is missing", {
   withr::with_tempdir({
     file.create("dummy.csv")

--- a/tests/testthat/test-read-results.R
+++ b/tests/testthat/test-read-results.R
@@ -46,3 +46,10 @@ test_that("read_manual_test_results() works correctly", {
     expect_true(all(purrr::map_lgl(res_df[[.n]], ~nchar(.x) > 1)))
   })
 })
+
+test_that("read_manual_test_results() gives helpful error on empty input", {
+  withr::with_tempdir({
+    expect_error(read_manual_test_results(getwd()),
+                 class = "mrgvalidate_input_error")
+  })
+})


### PR DESCRIPTION
This series updates both `read_csv_test_results` and `read_manual_test_results` to fail more helpfully when the initial `list.files` call comes up empty (no CSV files or no manual test directories).
