### PR TITLE
test: update the expected matrix text

### DIFF
--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -38,8 +38,8 @@ MAT_TITLE <- "# Traceability Matrix"
 MAT_BOILER <- '
 ## Scope
 
-This traceability matrix links requirement specifications and test results to
-specific user stories for the proposed software release. User stories, including
-requirements and test specifications, are listed in the Requirements Specification.
+This Traceability Matrix links test results to specific user stories for the 
+proposed software release. User stories, including requirements and test specifications, 
+are listed in the Requirements Specification.
 '
 


### PR DESCRIPTION
This text should have been updated with 7c53376 (Changes to wording in
Trace Matrix, 2021-08-20).

---

Bah, sorry for not catching this in my review of gh-65.

<img width="652" alt="mrgvalidae-tests-210825" src="https://user-images.githubusercontent.com/1297788/130863487-158bd68c-6599-4635-bf34-61576ccc7743.png">
