### PR TITLE
set up drone

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -3,6 +3,7 @@
 ^.*\.Rproj$
 ^\.Rproj\.user$
 ^.Rprofile$
+^.drone.yml$
 ^LICENSE\.md$
 ^docs/
 pkgr.yml

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,113 @@
+---
+kind: pipeline
+type: docker
+name: cran-latest
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+- name: pull
+  image: omerxx/drone-ecr-auth
+  commands:
+  - $(aws ecr get-login --no-include-email --region us-east-1)
+  - docker pull 906087756158.dkr.ecr.us-east-1.amazonaws.com/r-dev-ci-mpn-4.0:cran-latest
+  volumes:
+  - name: docker.sock
+    path: /var/run/docker.sock
+
+- name: "Check package: R 4.0"
+  pull: never
+  image: 906087756158.dkr.ecr.us-east-1.amazonaws.com/r-dev-ci-mpn-4.0:cran-latest
+  commands:
+  - R -s -e 'devtools::install_deps(upgrade = '"'"'always'"'"')'
+  - R -s -e 'devtools::load_all(); sessioninfo::session_info()'
+  - R -s -e 'devtools::check(env_vars = c("NOT_CRAN" = "true"))'
+  environment:
+    USER: drone
+  volumes:
+  - name: cache
+    path: /ephemeral
+
+volumes:
+- name: docker.sock
+  host:
+    path: /var/run/docker.sock
+- name: cache
+  temp: {}
+
+trigger:
+  event:
+    exclude:
+    - promote
+
+---
+kind: pipeline
+type: docker
+name: mrgvalidate-release
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+- name: pull
+  image: omerxx/drone-ecr-auth
+  commands:
+  - $(aws ecr get-login --no-include-email --region us-east-1)
+  - docker pull 906087756158.dkr.ecr.us-east-1.amazonaws.com/r-dev-ci-mpn-4.0:latest
+  volumes:
+  - name: docker.sock
+    path: /var/run/docker.sock
+
+- name: Build package
+  pull: never
+  image: 906087756158.dkr.ecr.us-east-1.amazonaws.com/r-dev-ci-mpn-4.0:latest
+  commands:
+  - git config --global user.email drone@metrumrg.com
+  - git config --global user.name Drony
+  - git fetch --tags
+  - R -s -e 'devtools::install_deps(upgrade = '"'"'always'"'"')'
+  - R -s -e 'pkgpub::create_tagged_repo(.dir = '"'"'/ephemeral'"'"')'
+  volumes:
+  - name: cache
+    path: /ephemeral
+
+- name: "Publish package: ${DRONE_TAG}"
+  pull: if-not-exists
+  image: plugins/s3
+  settings:
+    bucket: mpn.metworx.dev
+    source: /ephemeral/${DRONE_TAG}/**/*
+    strip_prefix: /ephemeral/${DRONE_TAG}/
+    target: /releases/${DRONE_REPO_NAME}/${DRONE_TAG}
+  volumes:
+  - name: cache
+    path: /ephemeral
+
+- name: "Publish package: latest_tag"
+  pull: if-not-exists
+  image: plugins/s3
+  settings:
+    bucket: mpn.metworx.dev
+    source: /ephemeral/${DRONE_TAG}/**/*
+    strip_prefix: /ephemeral/${DRONE_TAG}/
+    target: /releases/${DRONE_REPO_NAME}/latest_tag
+  volumes:
+  - name: cache
+    path: /ephemeral
+
+volumes:
+- name: docker.sock
+  host:
+    path: /var/run/docker.sock
+- name: cache
+  temp: {}
+
+trigger:
+  event:
+  - tag
+
+depends_on:
+- cran-latest

--- a/.drone.yml
+++ b/.drone.yml
@@ -68,20 +68,21 @@ steps:
   - git config --global user.email drone@metrumrg.com
   - git config --global user.name Drony
   - git fetch --tags
+  - git checkout 1.0.2
   - R -s -e 'devtools::install_deps(upgrade = '"'"'always'"'"')'
   - R -s -e 'pkgpub::create_tagged_repo(.dir = '"'"'/ephemeral'"'"')'
   volumes:
   - name: cache
     path: /ephemeral
 
-- name: "Publish package: ${DRONE_TAG}"
+- name: "Publish package: 1.0.2"
   pull: if-not-exists
   image: plugins/s3
   settings:
     bucket: mpn.metworx.dev
-    source: /ephemeral/${DRONE_TAG}/**/*
-    strip_prefix: /ephemeral/${DRONE_TAG}/
-    target: /releases/${DRONE_REPO_NAME}/${DRONE_TAG}
+    source: /ephemeral/1.0.2/**/*
+    strip_prefix: /ephemeral/1.0.2/
+    target: /releases/${DRONE_REPO_NAME}/1.0.2
   volumes:
   - name: cache
     path: /ephemeral
@@ -91,8 +92,8 @@ steps:
   image: plugins/s3
   settings:
     bucket: mpn.metworx.dev
-    source: /ephemeral/${DRONE_TAG}/**/*
-    strip_prefix: /ephemeral/${DRONE_TAG}/
+    source: /ephemeral/1.0.2/**/*
+    strip_prefix: /ephemeral/1.0.2/
     target: /releases/${DRONE_REPO_NAME}/latest_tag
   volumes:
   - name: cache
@@ -107,7 +108,7 @@ volumes:
 
 trigger:
   event:
-  - tag
+  - push
 
 depends_on:
 - cran-latest

--- a/.drone.yml
+++ b/.drone.yml
@@ -68,21 +68,20 @@ steps:
   - git config --global user.email drone@metrumrg.com
   - git config --global user.name Drony
   - git fetch --tags
-  - git checkout 1.0.2
   - R -s -e 'devtools::install_deps(upgrade = '"'"'always'"'"')'
   - R -s -e 'pkgpub::create_tagged_repo(.dir = '"'"'/ephemeral'"'"')'
   volumes:
   - name: cache
     path: /ephemeral
 
-- name: "Publish package: 1.0.2"
+- name: "Publish package: ${DRONE_TAG}"
   pull: if-not-exists
   image: plugins/s3
   settings:
     bucket: mpn.metworx.dev
-    source: /ephemeral/1.0.2/**/*
-    strip_prefix: /ephemeral/1.0.2/
-    target: /releases/${DRONE_REPO_NAME}/1.0.2
+    source: /ephemeral/${DRONE_TAG}/**/*
+    strip_prefix: /ephemeral/${DRONE_TAG}/
+    target: /releases/${DRONE_REPO_NAME}/${DRONE_TAG}
   volumes:
   - name: cache
     path: /ephemeral
@@ -92,8 +91,8 @@ steps:
   image: plugins/s3
   settings:
     bucket: mpn.metworx.dev
-    source: /ephemeral/1.0.2/**/*
-    strip_prefix: /ephemeral/1.0.2/
+    source: /ephemeral/${DRONE_TAG}/**/*
+    strip_prefix: /ephemeral/${DRONE_TAG}/
     target: /releases/${DRONE_REPO_NAME}/latest_tag
   volumes:
   - name: cache
@@ -108,7 +107,7 @@ volumes:
 
 trigger:
   event:
-  - push
+  - tag
 
 depends_on:
 - cran-latest

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: mrgvalidate
 Type: Package
 Title: Create Validation Docs For R Packages
-Version: 1.0.2
-Authors@R: 
+Version: 1.0.2.7000
+Authors@R:
     c(person(given = "Devin",
            family = "Pastoor",
            role = c("aut", "cre"),


### PR DESCRIPTION
Copy `.drone.yml` over from mrgvalprep.  This is mounting `/var/run/docker.sock`, so I think we'll need to get an admin to mark this as a trusted repo (edit: never mind, looks like it already is, probably from previous unmerged PRs that started to set up drone).  Aside from that, perhaps this will just work.