### PR TITLE
pkgr.yml: drop renv

### DIFF
--- a/pkgr.yml
+++ b/pkgr.yml
@@ -4,7 +4,6 @@ Descriptions:
 
 Packages:
   - devtools
-  - renv
   - pkgdown
 
 Repos:


### PR DESCRIPTION
The instructions in README.md expect renv to be on the system.
Initializing renv and then having pkgr install renv within the library
increases the chances of getting into confused states, particularly
given pkgr <3.1.0 is incompatible with the default library location
that renv >=0.15 uses for package projects.