### PR TITLE
Release 2.0.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: mrgvalidate
 Type: Package
 Title: Create Validation Docs For R Packages
-Version: 1.0.2.9000
+Version: 2.0.0
 Authors@R:
     c(person(given = "Seth",
            family = "Green",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# Development
+# mrgvalidate 2.0.0
 
 ## New Features
  - Overhaul of entire package (is not backwards compatible).

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
  - Overhaul of entire package (is not backwards compatible).
  - Generated documents are now created from parameterized `rmarkdown` documents, instead of glueing text together.
  - There are a total of 7 validation documents (up from 3). The tracability matrix and requirements specification documents were carried over, but the other 5 are mostly new content.
- - `create_validation_docs` has been replaced by `create_package_docs()` and `create_metworx_docs()` for packages and the Metworx platform respectfully.
+ - `create_validation_docs` has been replaced by `create_package_docs()` and `create_metworx_docs()` for packages and the Metworx platform respectively.
     - The arguments of these two functions are largely the same as `create_validation_docs`.
     - `create_package_docs()` has an added `language` argument, that will change the boilerplate text depending on the language the package was predominantly coded in.
  - Release notes are now required. This should contain two top-level headers for "Changes and New Features" and "Bug Fixes". For packages, this can typically be extracted from the relevant entry in the `NEWS.md` file.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ The purpose of the `mrgvalidate` package is to generate 7 specific documents tha
 
 * release-notes.docx
 * validation-plan.docx
-* validation-testing.docx
+* testing-plan.docx
 * requirements-specification.docx
 * traceability-matrix.docx
 * testing-results.docx

--- a/pkgr.yml
+++ b/pkgr.yml
@@ -12,3 +12,4 @@ Repos:
 
 Lockfile:
   Type: renv
+

--- a/vignettes/basic-usage.Rmd
+++ b/vignettes/basic-usage.Rmd
@@ -17,9 +17,11 @@ knitr::opts_chunk$set(
 )
 library(knitr)
 library(kableExtra)
-if (interactive()) {
-  devtools::load_all()
-}
+library(dplyr)
+library(tidyr)
+# if (interactive()) {
+#   devtools::load_all()
+# }
 ```
 
 # Introduction

--- a/vignettes/basic-usage.Rmd
+++ b/vignettes/basic-usage.Rmd
@@ -30,7 +30,7 @@ The purpose of the `mrgvalidate` package is to generate 7 specific documents tha
 
 * release-notes.docx
 * validation-plan.docx
-* validation-testing.docx
+* testing-plan.docx
 * requirements-specification.docx
 * traceability-matrix.docx
 * testing-results.docx


### PR DESCRIPTION
### [Release Diff](https://github.com/metrumresearchgroup/mrgvalidate/compare/1.0.2...release/2.0.0)

## New Features 
- Overhaul of entire package (is not backwards compatible).
 - Generated documents are now created from parameterized `rmarkdown` documents, instead of glueing text together.
 - There are a total of 7 validation documents (up from 3). The tracability matrix and requirements specification documents were carried over, but the other 5 are mostly new content.
 - `create_validation_docs` has been replaced by `create_package_docs()` and `create_metworx_docs()` for packages and the Metworx platform respectfully.
    - The arguments of these two functions are largely the same as `create_validation_docs`.
    - `create_package_docs()` has an added `language` argument, that will change the boilerplate text depending on the language the package was predominantly coded in.
 - Release notes are now required. This should contain two top-level headers for "Changes and New Features" and "Bug Fixes". For packages, this can typically be extracted from the relevant entry in the `NEWS.md` file.
 - More helpful warning and error messages.
 - `create_templates()` was introduced for easily creating templates for both packages and the Metworx platform.
 - More comprehensive test suite.
 
## Bug fixes
 - Missing links between requirements and stories were previously unreported. It will now error out if any are found.
 